### PR TITLE
Use of proxy with hardcoded data in the code.

### DIFF
--- a/bin/maxmind_db_update_command.py
+++ b/bin/maxmind_db_update_command.py
@@ -79,7 +79,22 @@ class UpdateMaxMindDatabase(GeneratingCommand):
 
 
     def download_mmdb_database(self, license_key):
-        r = requests.get(MaxMindDatabaseDownloadLink.format(license_key), allow_redirects=True)
+        proxies = {
+            "http" : "http://<ip-address>:<port>",
+            "https" : "https://<ip-address>:<port>"
+        }
+
+        '''
+        # Use following format if using proxy with credentials
+
+        proxies = {
+            "http" : "http://<username>:<password>@<ip-address>:<port>",
+            "https" : "https://<username>:<password>@<ip-address>:<port>"
+        }
+        '''
+
+        r = requests.get(MaxMindDatabaseDownloadLink.format(license_key), allow_redirects=True, proxies=proxies)
+        
         if r.status_code == 200:
             open(DB_TEMP_DOWNLOAD, 'wb').write(r.content)
             try:

--- a/bin/maxmind_db_update_command.py
+++ b/bin/maxmind_db_update_command.py
@@ -79,19 +79,16 @@ class UpdateMaxMindDatabase(GeneratingCommand):
 
 
     def download_mmdb_database(self, license_key):
-        proxies = {
-            "http" : "http://<ip-address>:<port>",
-            "https" : "https://<ip-address>:<port>"
-        }
 
-        '''
-        # Use following format if using proxy with credentials
-
+        # NOTE - Proxy Configuration
+        # Remove '<username>:<password>@' part if using proxy without authentication (just use ip:port format)
+        # Understand the risk of storing password in plain-text when using proxy with authentication
         proxies = {
             "http" : "http://<username>:<password>@<ip-address>:<port>",
             "https" : "https://<username>:<password>@<ip-address>:<port>"
         }
-        '''
+
+        # NOTE - Please visit GitHub page (https://github.com/VatsalJagani/Splunk-App-Auto-Update-MaxMind-Database), if you are developer and want to help improving this App in anyways
 
         r = requests.get(MaxMindDatabaseDownloadLink.format(license_key), allow_redirects=True, proxies=proxies)
         


### PR DESCRIPTION
* Use it after understanding the risk when using proxies with authentication as proxy credentials will be hardcoded in the python file in plain text (not encrypted).

In the future, we are planning to provide a UI Proxy Configuration page (built with the Add-on builder) and use configuration that way.
* If you are a developer your contribution is most welcome.