### PR TITLE
Fix app wording to reflect v3.1 change to daily DB updates

### DIFF
--- a/default/data/ui/views/mmdb_auto_update_app_configuration.xml
+++ b/default/data/ui/views/mmdb_auto_update_app_configuration.xml
@@ -76,7 +76,7 @@
       </html>
       <html>
         <div>
-          <p>The App updates the database automatically every week.</p>
+          <p>The App updates the database automatically every day at 07:00.</p>
           <p>You can also update the database manually by running <a target="_blank" href="/app/splunk_maxmind_db_auto_update/search?q=%7C%20maxminddbupdate&amp;display.page.search.mode=smart&amp;dispatch.sample_ratio=1&amp;earliest=-24h%40h&amp;latest=now&amp;display.page.search.tab=statistics&amp;display.general.type=statistics">this search</a>.</p>
         </div>
       </html>


### PR DESCRIPTION
Fix text in to UI now that app now updates each day at 7am https://github.com/CrossRealms/Splunk-App-Auto-Update-MaxMind-Database/blob/945fefd7cca1a406ee2d28ee7a92bf3ce6869457/default/savedsearches.conf#L6

Note: it would be worth updating the app store images so that the new wording is included as well